### PR TITLE
[nightshift] readme-improvements: fix hardcoded paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Wrong tags do not release the session. The block stays active until the paired a
 ### web
 
 ```bash
-cd /home/ubuntu/workspace/ancla/site
+cd site
 pnpm install
 pnpm dev
 ```
@@ -79,13 +79,12 @@ pnpm dev
 ### local verification
 
 ```bash
-cd /home/ubuntu/workspace/ancla/site
+cd site
 pnpm lint
 pnpm build
 ```
 
 ```bash
-cd /home/ubuntu/workspace/ancla
 docker run --rm \
   -v "$PWD/ios:/workspace" \
   -w /workspace \


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** readme-improvements
**Category:** pr
**Summary:** Fixed hardcoded  paths in Quickstart section to use relative paths (, ). This makes the instructions work regardless of where the repo is cloned.

Merge if useful, close if not.