### PR TITLE
feat: add usage history for completed sessions

### DIFF
--- a/ios/ancla-app/app-view-model.swift
+++ b/ios/ancla-app/app-view-model.swift
@@ -106,6 +106,10 @@ final class AppViewModel {
     !snapshot.modes.isEmpty
   }
 
+  var recentSessionHistory: [SessionHistoryEntry] {
+    AnclaCore.recentHistory(in: snapshot)
+  }
+
   var isNFCAvailable: Bool {
     diagnostics.items.first(where: { $0.id == "nfc" })?.value == "Ready"
   }
@@ -310,14 +314,31 @@ final class AppViewModel {
         throw ValidationError.mismatchedTag
       }
 
+      guard
+        let pairedTag = snapshot.pairedTag,
+        let mode = snapshot.modes.first(where: { $0.id == activeSession.modeId })
+      else {
+        throw ValidationError.missingMode
+      }
+
+      let releasedAt = Date.now
       shieldingService.clear()
-      snapshot.activeSession = AnchorSession(
+      let releasedSession = AnchorSession(
         id: activeSession.id,
         pairedTagId: activeSession.pairedTagId,
         modeId: activeSession.modeId,
         state: .released,
         armedAt: activeSession.armedAt,
-        releasedAt: .now
+        releasedAt: releasedAt
+      )
+      snapshot.activeSession = releasedSession
+      snapshot = AnclaCore.recordHistory(
+        in: snapshot,
+        session: releasedSession,
+        mode: mode,
+        pairedTag: pairedTag,
+        releaseMethod: .anchor,
+        releasedAt: releasedAt
       )
       try persist()
     }

--- a/ios/ancla-app/app-view-model.swift
+++ b/ios/ancla-app/app-view-model.swift
@@ -470,7 +470,9 @@ final class AppViewModel {
   }
 
   func refreshDiagnostics() {
-    let environment = runtimeDiagnosticsProbe.environment(for: buildVariant)
+    let environment = automationAdjustedEnvironment(
+      runtimeDiagnosticsProbe.environment(for: buildVariant)
+    )
 
     if isSideloadLiteBuild {
       snapshot.isAuthorized = true
@@ -529,6 +531,24 @@ final class AppViewModel {
     !selection.applicationTokens.isEmpty
       || !selection.categoryTokens.isEmpty
       || !selection.webDomainTokens.isEmpty
+  }
+
+  private func automationAdjustedEnvironment(
+    _ environment: RuntimeEnvironmentSnapshot
+  ) -> RuntimeEnvironmentSnapshot {
+    guard AutomatedTestConfig.usesSimulatedNFC else {
+      return environment
+    }
+
+    return RuntimeEnvironmentSnapshot(
+      buildLabel: environment.buildLabel,
+      buildDetail: environment.buildDetail,
+      storageLabel: environment.storageLabel,
+      storageDetail: environment.storageDetail,
+      storageTone: environment.storageTone,
+      nfcAvailable: true,
+      screenTimeAuthorization: environment.screenTimeAuthorization
+    )
   }
 
   private func runTask(

--- a/ios/ancla-app/content-view.swift
+++ b/ios/ancla-app/content-view.swift
@@ -193,6 +193,29 @@ struct ContentView: View {
         surfaceDivider
 
         sectionBlock(
+          title: "Recent sessions",
+          content: {
+            VStack(spacing: 12) {
+              if viewModel.recentSessionHistory.isEmpty {
+                informativeRow(
+                  title: "No sessions recorded",
+                  detail: "Completed sessions will appear here after you release them with the paired anchor.",
+                  accentColor: AnclaTheme.primaryText,
+                  highlight: false,
+                  trailingSymbol: "clock.arrow.circlepath"
+                )
+              } else {
+                ForEach(viewModel.recentSessionHistory) { entry in
+                  historyRow(entry)
+                }
+              }
+            }
+          }
+        )
+
+        surfaceDivider
+
+        sectionBlock(
           title: "Modes",
           content: {
             VStack(spacing: 12) {
@@ -504,6 +527,36 @@ struct ContentView: View {
               isSelected ? AnclaTheme.accentStroke.opacity(0.55) : AnclaTheme.panelStroke.opacity(0.75),
               lineWidth: 1
             )
+        )
+    )
+  }
+
+  private func historyRow(_ entry: SessionHistoryEntry) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .firstTextBaseline, spacing: 12) {
+        Text(entry.modeName)
+          .font(.ancla(15, weight: .medium))
+          .foregroundStyle(AnclaTheme.primaryText)
+
+        Spacer(minLength: 0)
+
+        Text(historyDurationLabel(for: entry))
+          .font(.ancla(12, weight: .medium))
+          .foregroundStyle(AnclaTheme.successText)
+      }
+
+      Text(historySubtitle(for: entry))
+        .font(.ancla(12))
+        .foregroundStyle(AnclaTheme.secondaryText)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(16)
+    .background(
+      RoundedRectangle(cornerRadius: 18, style: .continuous)
+        .fill(AnclaTheme.panelInteractive)
+        .overlay(
+          RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .stroke(AnclaTheme.panelStroke.opacity(0.75), lineWidth: 1)
         )
     )
   }
@@ -885,6 +938,37 @@ struct ContentView: View {
       return "checkmark"
     case .error:
       return "exclamationmark"
+    }
+  }
+
+  private func historyDurationLabel(for entry: SessionHistoryEntry) -> String {
+    let seconds = Int(entry.duration.rounded())
+    if seconds < 60 {
+      return "\(seconds)s"
+    }
+
+    let minutes = seconds / 60
+    if minutes < 60 {
+      return "\(minutes)m"
+    }
+
+    let hours = minutes / 60
+    let remainingMinutes = minutes % 60
+    if remainingMinutes == 0 {
+      return "\(hours)h"
+    }
+
+    return "\(hours)h \(remainingMinutes)m"
+  }
+
+  private func historySubtitle(for entry: SessionHistoryEntry) -> String {
+    "\(historyMethodLabel(for: entry.releaseMethod)) via \(entry.pairedTagName) • \(entry.releasedAt.formatted(date: .abbreviated, time: .shortened))"
+  }
+
+  private func historyMethodLabel(for method: SessionReleaseMethod) -> String {
+    switch method {
+    case .anchor:
+      return "Released"
     }
   }
 }

--- a/ios/ancla-core-tests/ancla-core-tests.swift
+++ b/ios/ancla-core-tests/ancla-core-tests.swift
@@ -144,6 +144,60 @@ final class AnclaCoreTests: XCTestCase {
     XCTAssertFalse(AnclaCore.canArmSelectedMode(blockingSnapshot))
   }
 
+  func testRecordHistoryAppendsEntryAndRecentHistorySortsLatestFirst() {
+    let pairedTag = PairedTag(uidHash: "paired-hash", displayName: "Desk sticker")
+    let mode = BlockMode(name: "Work", selectionData: Data(), isDefault: true)
+    let firstRelease = Date(timeIntervalSince1970: 1_710_000_000)
+    let secondRelease = firstRelease.addingTimeInterval(600)
+
+    let firstSession = AnchorSession(
+      pairedTagId: pairedTag.id,
+      modeId: mode.id,
+      state: .released,
+      armedAt: firstRelease.addingTimeInterval(-1_800),
+      releasedAt: firstRelease
+    )
+    let secondSession = AnchorSession(
+      pairedTagId: pairedTag.id,
+      modeId: mode.id,
+      state: .released,
+      armedAt: secondRelease.addingTimeInterval(-900),
+      releasedAt: secondRelease
+    )
+
+    var snapshot = AppSnapshot(
+      isAuthorized: true,
+      pairedTag: pairedTag,
+      modes: [mode],
+      activeSession: secondSession
+    )
+
+    snapshot = AnclaCore.recordHistory(
+      in: snapshot,
+      session: firstSession,
+      mode: mode,
+      pairedTag: pairedTag,
+      releaseMethod: .anchor,
+      releasedAt: firstRelease
+    )
+    snapshot = AnclaCore.recordHistory(
+      in: snapshot,
+      session: secondSession,
+      mode: mode,
+      pairedTag: pairedTag,
+      releaseMethod: .anchor,
+      releasedAt: secondRelease
+    )
+
+    let recent = AnclaCore.recentHistory(in: snapshot)
+
+    XCTAssertEqual(recent.count, 2)
+    XCTAssertEqual(recent.map(\.releasedAt), [secondRelease, firstRelease])
+    XCTAssertEqual(recent[0].modeName, "Work")
+    XCTAssertEqual(recent[0].pairedTagName, "Desk sticker")
+    XCTAssertEqual(recent[0].releaseMethod, .anchor)
+  }
+
   func testRuntimeDiagnosticsFlagMissingStorageBeforeAnythingElse() {
     let diagnostics = AnclaCore.runtimeDiagnostics(
       snapshot: AppSnapshot(),

--- a/ios/ancla-lite/ancla-lite-support.swift
+++ b/ios/ancla-lite/ancla-lite-support.swift
@@ -27,6 +27,21 @@ enum SideloadLiteError: LocalizedError {
   }
 }
 
+enum AutomatedTestConfig {
+  private static let stickerHashesKey = "ANCLA_TEST_STICKER_HASHES"
+
+  static var simulatedStickerHashes: [String] {
+    ProcessInfo.processInfo.environment[stickerHashesKey]?
+      .split(separator: ",")
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty } ?? []
+  }
+
+  static var usesSimulatedNFC: Bool {
+    !simulatedStickerHashes.isEmpty
+  }
+}
+
 struct LocalSnapshotStore: AppSnapshotStore {
   private let encoder = JSONEncoder()
   private let decoder = JSONDecoder()
@@ -80,8 +95,13 @@ final class LiteShieldingService: Shielding {
 @MainActor
 final class LiteStickerPairingService: StickerPairing {
   private let scanner = StickerPairingService()
+  private var simulatedHashes = AutomatedTestConfig.simulatedStickerHashes
 
   func scanSticker() async throws -> String {
+    if !simulatedHashes.isEmpty {
+      return simulatedHashes.removeFirst()
+    }
+
     try await scanner.scanSticker()
   }
 }

--- a/ios/ancla-lite/ancla-lite-support.swift
+++ b/ios/ancla-lite/ancla-lite-support.swift
@@ -102,6 +102,6 @@ final class LiteStickerPairingService: StickerPairing {
       return simulatedHashes.removeFirst()
     }
 
-    try await scanner.scanSticker()
+    return try await scanner.scanSticker()
   }
 }

--- a/ios/ancla-shared/ancla-core.swift
+++ b/ios/ancla-shared/ancla-core.swift
@@ -48,4 +48,43 @@ enum AnclaCore {
       && !snapshot.modes.isEmpty
       && !activeSessionIsBlocking(snapshot)
   }
+
+  static func recentHistory(
+    in snapshot: AppSnapshot,
+    limit: Int = 10
+  ) -> [SessionHistoryEntry] {
+    let entries = snapshot.sessionHistory.sorted { lhs, rhs in
+      lhs.releasedAt > rhs.releasedAt
+    }
+
+    guard limit < entries.count else {
+      return entries
+    }
+
+    return Array(entries.prefix(limit))
+  }
+
+  static func recordHistory(
+    in snapshot: AppSnapshot,
+    session: AnchorSession,
+    mode: BlockMode,
+    pairedTag: PairedTag,
+    releaseMethod: SessionReleaseMethod,
+    releasedAt: Date
+  ) -> AppSnapshot {
+    var updated = snapshot
+    updated.sessionHistory.append(
+      SessionHistoryEntry(
+        sessionID: session.id,
+        pairedTagId: pairedTag.id,
+        pairedTagName: pairedTag.displayName,
+        modeId: mode.id,
+        modeName: mode.name,
+        armedAt: session.armedAt,
+        releasedAt: releasedAt,
+        releaseMethod: releaseMethod
+      )
+    )
+    return updated
+  }
 }

--- a/ios/ancla-shared/ancla-models.swift
+++ b/ios/ancla-shared/ancla-models.swift
@@ -65,9 +65,52 @@ struct AnchorSession: Codable, Equatable, Identifiable {
   }
 }
 
+enum SessionReleaseMethod: String, Codable {
+  case anchor
+}
+
+struct SessionHistoryEntry: Codable, Equatable, Identifiable {
+  let id: UUID
+  let sessionID: UUID
+  let pairedTagId: UUID
+  let pairedTagName: String
+  let modeId: UUID
+  let modeName: String
+  let armedAt: Date
+  let releasedAt: Date
+  let releaseMethod: SessionReleaseMethod
+
+  init(
+    id: UUID = UUID(),
+    sessionID: UUID,
+    pairedTagId: UUID,
+    pairedTagName: String,
+    modeId: UUID,
+    modeName: String,
+    armedAt: Date,
+    releasedAt: Date,
+    releaseMethod: SessionReleaseMethod
+  ) {
+    self.id = id
+    self.sessionID = sessionID
+    self.pairedTagId = pairedTagId
+    self.pairedTagName = pairedTagName
+    self.modeId = modeId
+    self.modeName = modeName
+    self.armedAt = armedAt
+    self.releasedAt = releasedAt
+    self.releaseMethod = releaseMethod
+  }
+
+  var duration: TimeInterval {
+    max(0, releasedAt.timeIntervalSince(armedAt))
+  }
+}
+
 struct AppSnapshot: Codable, Equatable {
   var isAuthorized = false
   var pairedTag: PairedTag?
   var modes: [BlockMode] = []
   var activeSession: AnchorSession?
+  var sessionHistory: [SessionHistoryEntry] = []
 }

--- a/ios/ancla-tests/app-view-model-tests.swift
+++ b/ios/ancla-tests/app-view-model-tests.swift
@@ -203,6 +203,42 @@ final class AppViewModelTests: XCTestCase {
     XCTAssertEqual(shielding.clearCallCount, 1)
   }
 
+  func testReleaseAppendsUsageHistoryEntry() async throws {
+    let selection = FamilyActivitySelection()
+    let mode = try BlockMode(name: "Work", selection: selection, isDefault: true)
+    let pairedTag = PairedTag(uidHash: "paired-hash", displayName: "Desk sticker")
+    let activeSession = AnchorSession(
+      pairedTagId: pairedTag.id,
+      modeId: mode.id,
+      state: .armed
+    )
+    let store = InMemorySnapshotStore(
+      snapshot: AppSnapshot(
+        isAuthorized: true,
+        pairedTag: pairedTag,
+        modes: [mode],
+        activeSession: activeSession
+      )
+    )
+    let shielding = FakeShieldingService()
+    let stickerService = FakeStickerPairingService(nextHashes: ["paired-hash"])
+    let viewModel = AppViewModel(
+      store: store,
+      authorizationClient: FakeAuthorizationClient(),
+      shieldingService: shielding,
+      stickerPairingService: stickerService
+    )
+
+    await viewModel.releaseActiveSession()
+
+    XCTAssertEqual(viewModel.snapshot.activeSession?.state, .released)
+    XCTAssertEqual(viewModel.snapshot.sessionHistory.count, 1)
+    XCTAssertEqual(viewModel.snapshot.sessionHistory[0].modeName, "Work")
+    XCTAssertEqual(viewModel.snapshot.sessionHistory[0].pairedTagName, "Desk sticker")
+    XCTAssertEqual(viewModel.snapshot.sessionHistory[0].releaseMethod, .anchor)
+    XCTAssertEqual(viewModel.recentSessionHistory.count, 1)
+  }
+
   func testLoadRepairsMissingDefaultAndSelectsFirstMode() async throws {
     let selection = FamilyActivitySelection()
     let firstMode = try BlockMode(name: "Focus", selection: selection, isDefault: false)


### PR DESCRIPTION
Adds durable usage history for completed iPhone sessions.

**What changed**
- Adds durable `sessionHistory` entries to the shared snapshot model.
- Records a completed session when release succeeds.
- Surfaces recent session history on the main control screen.
- Adds sideload-only simulated NFC support so BrowserStack can exercise pair, start, and release flows even though BrowserStack re-signing does not preserve NFC entitlements.

**Verification**
- `docker run --rm -v \"$PWD/ios:/workspace\" -w /workspace swift:5.10-jammy swift test`
- GitHub Actions: `ios-sideload-lite-ipa` on `feat/usage-history`
- BrowserStack click-through on the branch IPA: pair anchor -> create mode -> start session -> release session -> verify the new `Recent sessions` entry on the final screen