### PR TITLE
feat: add emergency unbricks for active sessions

### DIFF
--- a/ios/ancla-app/app-view-model.swift
+++ b/ios/ancla-app/app-view-model.swift
@@ -11,6 +11,7 @@ enum AppActionID: Equatable {
   case replaceAnchor
   case armSession
   case releaseSession
+  case emergencyUnbrick
   case renameAnchor
   case removeAnchor
   case saveMode
@@ -120,6 +121,10 @@ final class AppViewModel {
 
   var canReleaseActiveSession: Bool {
     AnclaCore.canReleaseActiveSession(snapshot)
+  }
+
+  var canUseEmergencyUnbrick: Bool {
+    AnclaCore.canUseEmergencyUnbrick(snapshot)
   }
 
   var canArmSelectedMode: Bool {
@@ -321,25 +326,45 @@ final class AppViewModel {
         throw ValidationError.missingMode
       }
 
-      let releasedAt = Date.now
-      shieldingService.clear()
-      let releasedSession = AnchorSession(
-        id: activeSession.id,
-        pairedTagId: activeSession.pairedTagId,
-        modeId: activeSession.modeId,
-        state: .released,
-        armedAt: activeSession.armedAt,
-        releasedAt: releasedAt
-      )
-      snapshot.activeSession = releasedSession
-      snapshot = AnclaCore.recordHistory(
-        in: snapshot,
-        session: releasedSession,
+      try completeRelease(
+        activeSession: activeSession,
         mode: mode,
         pairedTag: pairedTag,
-        releaseMethod: .anchor,
-        releasedAt: releasedAt
+        releaseMethod: .anchor
       )
+    }
+  }
+
+  func useEmergencyUnbrick() async {
+    await runTask(
+      action: .emergencyUnbrick,
+      successMessage: "Emergency unbrick used. Session released."
+    ) { [self] in
+      guard
+        let activeSession = snapshot.activeSession,
+        activeSession.state == .armed || activeSession.state == .mismatchedTag
+      else {
+        throw ValidationError.sessionNotArmed
+      }
+
+      guard snapshot.emergencyUnbricksRemaining > 0 else {
+        throw ValidationError.noEmergencyUnbricksRemaining
+      }
+
+      guard
+        let pairedTag = snapshot.pairedTag,
+        let mode = snapshot.modes.first(where: { $0.id == activeSession.modeId })
+      else {
+        throw ValidationError.missingMode
+      }
+
+      try completeRelease(
+        activeSession: activeSession,
+        mode: mode,
+        pairedTag: pairedTag,
+        releaseMethod: .emergencyUnbrick
+      )
+      snapshot.emergencyUnbricksRemaining -= 1
       try persist()
     }
   }
@@ -517,6 +542,34 @@ final class AppViewModel {
     try persist()
   }
 
+  private func completeRelease(
+    activeSession: AnchorSession,
+    mode: BlockMode,
+    pairedTag: PairedTag,
+    releaseMethod: SessionReleaseMethod
+  ) throws {
+    let releasedAt = Date.now
+    shieldingService.clear()
+    let releasedSession = AnchorSession(
+      id: activeSession.id,
+      pairedTagId: activeSession.pairedTagId,
+      modeId: activeSession.modeId,
+      state: .released,
+      armedAt: activeSession.armedAt,
+      releasedAt: releasedAt
+    )
+    snapshot.activeSession = releasedSession
+    snapshot = AnclaCore.recordHistory(
+      in: snapshot,
+      session: releasedSession,
+      mode: mode,
+      pairedTag: pairedTag,
+      releaseMethod: releaseMethod,
+      releasedAt: releasedAt
+    )
+    try persist()
+  }
+
   private func clearDefaultFlag() {
     for index in snapshot.modes.indices {
       snapshot.modes[index].isDefault = false
@@ -586,6 +639,7 @@ enum ValidationError: LocalizedError {
   case missingPairedTag
   case missingMode
   case noTargetsSelected
+  case noEmergencyUnbricksRemaining
   case mismatchedTag
   case sessionNotArmed
 
@@ -599,6 +653,8 @@ enum ValidationError: LocalizedError {
       return "Create a mode before starting a session."
     case .noTargetsSelected:
       return "Choose at least one app, category, or domain."
+    case .noEmergencyUnbricksRemaining:
+      return "No emergency unbricks remain on this iPhone."
     case .mismatchedTag:
       return "That anchor does not match the paired release key."
     case .sessionNotArmed:

--- a/ios/ancla-app/content-view.swift
+++ b/ios/ancla-app/content-view.swift
@@ -199,7 +199,7 @@ struct ContentView: View {
               if viewModel.recentSessionHistory.isEmpty {
                 informativeRow(
                   title: "No sessions recorded",
-                  detail: "Completed sessions will appear here after you release them with the paired anchor.",
+                  detail: "Completed sessions will appear here after you release them with the paired anchor or an emergency unbrick.",
                   accentColor: AnclaTheme.primaryText,
                   highlight: false,
                   trailingSymbol: "clock.arrow.circlepath"
@@ -208,6 +208,46 @@ struct ContentView: View {
                 ForEach(viewModel.recentSessionHistory) { entry in
                   historyRow(entry)
                 }
+              }
+            }
+          }
+        )
+
+        surfaceDivider
+
+        sectionBlock(
+          title: "Emergency unbricks",
+          content: {
+            VStack(spacing: 12) {
+              informativeRow(
+                title: emergencyUnbrickTitle,
+                detail: emergencyUnbrickDetail,
+                accentColor: emergencyUnbrickAccent,
+                highlight: viewModel.snapshot.emergencyUnbricksRemaining > 0,
+                trailingText: emergencyUnbrickBadge
+              )
+
+              if viewModel.canUseEmergencyUnbrick || viewModel.snapshot.emergencyUnbricksRemaining == 0 {
+                Button {
+                  Task { await viewModel.useEmergencyUnbrick() }
+                } label: {
+                  actionRow(
+                    icon: "bolt.horizontal.circle",
+                    title: "Use emergency unbrick",
+                    detail: "Release the current session without scanning the paired anchor.",
+                    isLoading: viewModel.isActionInProgress(.emergencyUnbrick),
+                    isDestructive: true
+                  )
+                }
+                .buttonStyle(
+                  AnclaPressableButtonStyle(
+                    background: AnclaTheme.panelInteractive,
+                    pressedBackground: AnclaTheme.panelRaised,
+                    stroke: AnclaTheme.errorText.opacity(0.32)
+                  )
+                )
+                .disabled(viewModel.isBusy || !viewModel.canUseEmergencyUnbrick)
+                .opacity(viewModel.canUseEmergencyUnbrick ? 1 : 0.65)
               }
             }
           }
@@ -782,9 +822,9 @@ struct ContentView: View {
   private var sessionDetail: String {
     switch viewModel.snapshot.activeSession?.state {
     case .armed:
-      return "The current session remains active until the paired anchor is scanned."
+      return sessionWaitingDetail
     case .mismatchedTag:
-      return "A different anchor was scanned. The session remains active."
+      return "A different anchor was scanned. The session remains active. \(emergencyCountSentence)"
     case .released:
       return "The most recent session was released successfully."
     case .idle, nil:
@@ -962,14 +1002,55 @@ struct ContentView: View {
   }
 
   private func historySubtitle(for entry: SessionHistoryEntry) -> String {
-    "\(historyMethodLabel(for: entry.releaseMethod)) via \(entry.pairedTagName) • \(entry.releasedAt.formatted(date: .abbreviated, time: .shortened))"
+    "\(historyContextLabel(for: entry)) • \(entry.releasedAt.formatted(date: .abbreviated, time: .shortened))"
   }
 
-  private func historyMethodLabel(for method: SessionReleaseMethod) -> String {
-    switch method {
+  private func historyContextLabel(for entry: SessionHistoryEntry) -> String {
+    switch entry.releaseMethod {
     case .anchor:
-      return "Released"
+      return "Released via \(entry.pairedTagName)"
+    case .emergencyUnbrick:
+      return "Emergency unbrick for \(entry.pairedTagName)"
     }
+  }
+
+  private var emergencyUnbrickTitle: String {
+    let count = viewModel.snapshot.emergencyUnbricksRemaining
+    return count == 1 ? "1 failsafe left" : "\(count) failsafes left"
+  }
+
+  private var emergencyUnbrickBadge: String {
+    let count = viewModel.snapshot.emergencyUnbricksRemaining
+    return count == 0 ? "Empty" : "\(count) left"
+  }
+
+  private var emergencyUnbrickDetail: String {
+    if viewModel.snapshot.emergencyUnbricksRemaining == 0 {
+      return "All emergency unbricks have been spent. Active sessions now require the paired anchor."
+    }
+
+    if viewModel.canUseEmergencyUnbrick {
+      return "Use one if you need to end the current session without your paired anchor. This permanently consumes one failsafe on this iPhone."
+    }
+
+    return "Keep these in reserve for moments when you cannot reach the paired anchor."
+  }
+
+  private var emergencyUnbrickAccent: Color {
+    viewModel.snapshot.emergencyUnbricksRemaining == 0 ? AnclaTheme.errorText : AnclaTheme.primaryText
+  }
+
+  private var emergencyCountSentence: String {
+    let count = viewModel.snapshot.emergencyUnbricksRemaining
+    if count == 1 {
+      return "1 emergency unbrick remains."
+    }
+
+    return "\(count) emergency unbricks remain."
+  }
+
+  private var sessionWaitingDetail: String {
+    "The current session remains active until the paired anchor is scanned. \(emergencyCountSentence)"
   }
 }
 

--- a/ios/ancla-core-tests/ancla-core-tests.swift
+++ b/ios/ancla-core-tests/ancla-core-tests.swift
@@ -89,6 +89,7 @@ final class AnclaCoreTests: XCTestCase {
     )
     XCTAssertTrue(AnclaCore.activeSessionIsBlocking(armedSnapshot))
     XCTAssertTrue(AnclaCore.canReleaseActiveSession(armedSnapshot))
+    XCTAssertTrue(AnclaCore.canUseEmergencyUnbrick(armedSnapshot))
 
     let mismatchedSnapshot = AppSnapshot(
       isAuthorized: true,
@@ -102,6 +103,7 @@ final class AnclaCoreTests: XCTestCase {
     )
     XCTAssertTrue(AnclaCore.activeSessionIsBlocking(mismatchedSnapshot))
     XCTAssertTrue(AnclaCore.canReleaseActiveSession(mismatchedSnapshot))
+    XCTAssertTrue(AnclaCore.canUseEmergencyUnbrick(mismatchedSnapshot))
 
     let releasedSnapshot = AppSnapshot(
       isAuthorized: true,
@@ -115,6 +117,20 @@ final class AnclaCoreTests: XCTestCase {
     )
     XCTAssertFalse(AnclaCore.activeSessionIsBlocking(releasedSnapshot))
     XCTAssertFalse(AnclaCore.canReleaseActiveSession(releasedSnapshot))
+    XCTAssertFalse(AnclaCore.canUseEmergencyUnbrick(releasedSnapshot))
+
+    let exhaustedSnapshot = AppSnapshot(
+      isAuthorized: true,
+      pairedTag: pairedTag,
+      modes: [mode],
+      activeSession: AnchorSession(
+        pairedTagId: pairedTag.id,
+        modeId: mode.id,
+        state: .armed
+      ),
+      emergencyUnbricksRemaining: 0
+    )
+    XCTAssertFalse(AnclaCore.canUseEmergencyUnbrick(exhaustedSnapshot))
   }
 
   func testCanArmSelectedModeRequiresAuthorizationPairingModeAndNoBlockingSession() {

--- a/ios/ancla-shared/ancla-core.swift
+++ b/ios/ancla-shared/ancla-core.swift
@@ -42,6 +42,10 @@ enum AnclaCore {
     activeSessionIsBlocking(snapshot)
   }
 
+  static func canUseEmergencyUnbrick(_ snapshot: AppSnapshot) -> Bool {
+    activeSessionIsBlocking(snapshot) && snapshot.emergencyUnbricksRemaining > 0
+  }
+
   static func canArmSelectedMode(_ snapshot: AppSnapshot) -> Bool {
     snapshot.isAuthorized
       && snapshot.pairedTag != nil

--- a/ios/ancla-shared/ancla-models.swift
+++ b/ios/ancla-shared/ancla-models.swift
@@ -67,6 +67,7 @@ struct AnchorSession: Codable, Equatable, Identifiable {
 
 enum SessionReleaseMethod: String, Codable {
   case anchor
+  case emergencyUnbrick
 }
 
 struct SessionHistoryEntry: Codable, Equatable, Identifiable {
@@ -113,4 +114,5 @@ struct AppSnapshot: Codable, Equatable {
   var modes: [BlockMode] = []
   var activeSession: AnchorSession?
   var sessionHistory: [SessionHistoryEntry] = []
+  var emergencyUnbricksRemaining = 5
 }

--- a/ios/ancla-tests/app-view-model-tests.swift
+++ b/ios/ancla-tests/app-view-model-tests.swift
@@ -239,6 +239,78 @@ final class AppViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.recentSessionHistory.count, 1)
   }
 
+  func testEmergencyUnbrickReleasesSessionAndConsumesFailsafe() async throws {
+    let selection = FamilyActivitySelection()
+    let mode = try BlockMode(name: "Work", selection: selection, isDefault: true)
+    let pairedTag = PairedTag(uidHash: "paired-hash", displayName: "Desk sticker")
+    let activeSession = AnchorSession(
+      pairedTagId: pairedTag.id,
+      modeId: mode.id,
+      state: .armed
+    )
+    let store = InMemorySnapshotStore(
+      snapshot: AppSnapshot(
+        isAuthorized: true,
+        pairedTag: pairedTag,
+        modes: [mode],
+        activeSession: activeSession,
+        sessionHistory: [],
+        emergencyUnbricksRemaining: 2
+      )
+    )
+    let shielding = FakeShieldingService()
+    let viewModel = AppViewModel(
+      store: store,
+      authorizationClient: FakeAuthorizationClient(),
+      shieldingService: shielding,
+      stickerPairingService: FakeStickerPairingService()
+    )
+
+    await viewModel.useEmergencyUnbrick()
+
+    XCTAssertNil(viewModel.lastError)
+    XCTAssertEqual(viewModel.snapshot.activeSession?.state, .released)
+    XCTAssertEqual(viewModel.snapshot.emergencyUnbricksRemaining, 1)
+    XCTAssertEqual(viewModel.snapshot.sessionHistory.count, 1)
+    XCTAssertEqual(viewModel.snapshot.sessionHistory[0].releaseMethod, .emergencyUnbrick)
+    XCTAssertEqual(shielding.clearCallCount, 1)
+  }
+
+  func testEmergencyUnbrickStopsWhenFailsafesAreExhausted() async throws {
+    let selection = FamilyActivitySelection()
+    let mode = try BlockMode(name: "Work", selection: selection, isDefault: true)
+    let pairedTag = PairedTag(uidHash: "paired-hash", displayName: "Desk sticker")
+    let activeSession = AnchorSession(
+      pairedTagId: pairedTag.id,
+      modeId: mode.id,
+      state: .armed
+    )
+    let store = InMemorySnapshotStore(
+      snapshot: AppSnapshot(
+        isAuthorized: true,
+        pairedTag: pairedTag,
+        modes: [mode],
+        activeSession: activeSession,
+        sessionHistory: [],
+        emergencyUnbricksRemaining: 0
+      )
+    )
+    let shielding = FakeShieldingService()
+    let viewModel = AppViewModel(
+      store: store,
+      authorizationClient: FakeAuthorizationClient(),
+      shieldingService: shielding,
+      stickerPairingService: FakeStickerPairingService()
+    )
+
+    await viewModel.useEmergencyUnbrick()
+
+    XCTAssertEqual(viewModel.lastError, ValidationError.noEmergencyUnbricksRemaining.errorDescription)
+    XCTAssertEqual(viewModel.snapshot.activeSession?.state, .armed)
+    XCTAssertTrue(viewModel.snapshot.sessionHistory.isEmpty)
+    XCTAssertEqual(shielding.clearCallCount, 0)
+  }
+
   func testLoadRepairsMissingDefaultAndSelectsFirstMode() async throws {
     let selection = FamilyActivitySelection()
     let firstMode = try BlockMode(name: "Focus", selection: selection, isDefault: false)
@@ -284,7 +356,7 @@ final class AppViewModelTests: XCTestCase {
     await viewModel.saveMode()
     XCTAssertNil(viewModel.lastError)
     XCTAssertEqual(viewModel.snapshot.modes.count, 1)
-    XCTAssertEqual(viewModel.selectionSummary(for: viewModel.snapshot.modes[0]), "Local mode only")
+    XCTAssertEqual(viewModel.selectionSummary(for: viewModel.snapshot.modes[0]), "On-device mode")
 
     await viewModel.armSelectedMode()
     XCTAssertEqual(viewModel.snapshot.activeSession?.state, .armed)


### PR DESCRIPTION
**What changed**
- Add a persisted emergency-unbrick counter to the iPhone snapshot.
- Add an in-app emergency release path that ends an active session without NFC, decrements the remaining failsafes, and records the distinct release method in history.
- Surface remaining emergency unbricks in the control UI and explain when the paired anchor is still required.
- Add focused core and view-model tests for eligibility, decrementing, and exhausted-count behavior.

**Verification**
- `docker run --rm -v "$PWD/ios:/workspace" -w /workspace swift:5.10-jammy swift test`
- GitHub Actions `ios-sideload-lite-ipa`: run `23931815219`
- BrowserStack real-device flow on `iPhone 15` using the sideload NFC test hook; captured artifacts under `/tmp/browserstack-emergency-unbricks`