### PR TITLE
feat: require paired anchor tap to arm sessions

### DIFF
--- a/ios/ancla-app/app-view-model.swift
+++ b/ios/ancla-app/app-view-model.swift
@@ -287,8 +287,11 @@ final class AppViewModel {
         throw ValidationError.missingMode
       }
 
-      try arm(mode: mode)
-      feedback = ActionFeedback(message: "\"\(mode.name)\" is active.", tone: .success)
+      try await arm(mode: mode)
+      feedback = ActionFeedback(
+        message: "Paired anchor confirmed. \"\(mode.name)\" is active.",
+        tone: .success
+      )
     }
   }
 
@@ -298,8 +301,11 @@ final class AppViewModel {
         throw ValidationError.missingMode
       }
       selectedModeID = mode.id
-      try arm(mode: mode)
-      feedback = ActionFeedback(message: "\"\(mode.name)\" is active.", tone: .success)
+      try await arm(mode: mode)
+      feedback = ActionFeedback(
+        message: "Paired anchor confirmed. \"\(mode.name)\" is active.",
+        tone: .success
+      )
     }
   }
 
@@ -524,13 +530,18 @@ final class AppViewModel {
     try store.save(snapshot)
   }
 
-  private func arm(mode: BlockMode) throws {
+  private func arm(mode: BlockMode) async throws {
     guard snapshot.isAuthorized else {
       throw ValidationError.missingAuthorization
     }
 
     guard let pairedTag = snapshot.pairedTag else {
       throw ValidationError.missingPairedTag
+    }
+
+    let scannedHash = try await stickerPairingService.scanSticker()
+    guard scannedHash == pairedTag.uidHash else {
+      throw ValidationError.mismatchedTagOnArm
     }
 
     try shieldingService.apply(mode: mode)
@@ -640,6 +651,7 @@ enum ValidationError: LocalizedError {
   case missingMode
   case noTargetsSelected
   case noEmergencyUnbricksRemaining
+  case mismatchedTagOnArm
   case mismatchedTag
   case sessionNotArmed
 
@@ -655,6 +667,8 @@ enum ValidationError: LocalizedError {
       return "Choose at least one app, category, or domain."
     case .noEmergencyUnbricksRemaining:
       return "No emergency unbricks remain on this iPhone."
+    case .mismatchedTagOnArm:
+      return "Scan the paired anchor to start this session."
     case .mismatchedTag:
       return "That anchor does not match the paired release key."
     case .sessionNotArmed:

--- a/ios/ancla-app/content-view.swift
+++ b/ios/ancla-app/content-view.swift
@@ -795,7 +795,7 @@ struct ContentView: View {
       return "No anchor is paired to this iPhone yet."
     }
 
-    return "Only the paired anchor can release an active session."
+    return "The paired anchor is required to start and release sessions on this iPhone."
   }
 
   private var fingerprintValue: String {
@@ -860,9 +860,9 @@ struct ContentView: View {
     case .release:
       return "Release Session"
     case .arm:
-      return "Start Session"
+      return "Tap to Start Session"
     case .rearm:
-      return "Start New Session"
+      return "Tap to Start New Session"
     }
   }
 

--- a/ios/ancla-shared/ancla-runtime-diagnostics.swift
+++ b/ios/ancla-shared/ancla-runtime-diagnostics.swift
@@ -209,7 +209,7 @@ extension AnclaCore {
     }
 
     if !environment.nfcAvailable {
-      return "This iPhone cannot scan NFC anchors, so pairing and release are unavailable on this device."
+      return "This iPhone cannot scan NFC anchors, so pairing, start confirmation, and release are unavailable on this device."
     }
 
     if environment.screenTimeAuthorization != .notRequired,
@@ -230,7 +230,7 @@ extension AnclaCore {
       return "Only the paired anchor can release the current session."
     }
 
-    return "The selected mode is ready to start."
+    return "Tap the paired anchor to start the selected mode."
   }
 
   private static func sessionTitle(_ state: AnchorSessionState?) -> String {

--- a/ios/ancla-tests/app-view-model-tests.swift
+++ b/ios/ancla-tests/app-view-model-tests.swift
@@ -74,11 +74,12 @@ final class AppViewModelTests: XCTestCase {
       )
     )
     let shielding = FakeShieldingService()
+    let stickerService = FakeStickerPairingService(nextHashes: ["wrong-hash", "hash"])
     let viewModel = AppViewModel(
       store: store,
       authorizationClient: FakeAuthorizationClient(),
       shieldingService: shielding,
-      stickerPairingService: FakeStickerPairingService()
+      stickerPairingService: stickerService
     )
 
     await viewModel.armSelectedMode()
@@ -89,6 +90,10 @@ final class AppViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.lastError, ValidationError.missingPairedTag.errorDescription)
 
     viewModel.snapshot.pairedTag = PairedTag(uidHash: "hash", displayName: "Desk sticker")
+    await viewModel.armSelectedMode()
+    XCTAssertEqual(viewModel.lastError, ValidationError.mismatchedTagOnArm.errorDescription)
+    XCTAssertTrue(shielding.appliedModeIDs.isEmpty)
+
     await viewModel.armSelectedMode()
     XCTAssertNil(viewModel.lastError)
     XCTAssertEqual(shielding.appliedModeIDs, [mode.id])
@@ -338,7 +343,7 @@ final class AppViewModelTests: XCTestCase {
 
   func testSideloadLiteCanPairSaveArmAndReleaseLocally() async {
     let store = InMemorySnapshotStore()
-    let stickerService = FakeStickerPairingService(nextHashes: ["lite-hash", "lite-hash"])
+    let stickerService = FakeStickerPairingService(nextHashes: ["lite-hash", "lite-hash", "lite-hash"])
     let viewModel = AppViewModel(
       buildVariant: .sideloadLite,
       store: store,


### PR DESCRIPTION
**What changed**
- Require a scan of the already-paired anchor before a session can start.
- Reject mismatched start taps with a dedicated validation error instead of silently arming.
- Update the iPhone copy so the ready state and primary action clearly say the paired anchor is needed to start.
- Extend the view-model tests to cover mismatched-vs-matching arm scans and the sideload-lite local flow.

**Verification**
- `docker run --rm -v "$PWD/ios:/workspace" -w /workspace swift:5.10-jammy swift test`
- GitHub Actions `ios-sideload-lite-ipa`: run `23932025845`
- BrowserStack real-device flow on `iPhone 15`; captured artifacts under `/tmp/browserstack-tap-to-arm`
  - `05-home-after-save.xml` shows `Tap to Start Session` plus `Tap the paired anchor to start the selected mode.`
  - `06-home-after-arm.xml` shows `Paired anchor confirmed...` and `Release Session`